### PR TITLE
Add Turnstile functionality and fallback support

### DIFF
--- a/Block/Turnstile.php
+++ b/Block/Turnstile.php
@@ -85,4 +85,55 @@ class Turnstile extends Template
     {
         return 'cloudflare-turnstile-' . $this->filter->translitUrl($this->getAction());
     }
+
+    /**
+     * Check if Turnstile is enabled on frontend
+     *
+     * @return bool
+     */
+    public function isEnabled(): bool
+    {
+        return $this->config->isEnabledOnFront();
+    }
+
+    /**
+     * Retrieve sitekey
+     *
+     * @return string
+     */
+    public function getSiteKey(): string
+    {
+        return $this->config->getSiteKey();
+    }
+
+    /**
+     * Check if the current action/form is enabled
+     *
+     * @return bool
+     */
+    public function isFormEnabled(): bool
+    {
+        $forms = $this->config->getFrontendForms();
+        return in_array($this->getAction(), $forms);
+    }
+
+    /**
+     * Retrieve theme from config if not overridden
+     *
+     * @return string
+     */
+    public function getThemeFromConfig(): string
+    {
+        return $this->getTheme() ?: $this->config->getFrontendTheme();
+    }
+
+    /**
+     * Retrieve size from config if not overridden
+     *
+     * @return string
+     */
+    public function getSizeFromConfig(): string
+    {
+        return $this->getSize() ?: $this->config->getFrontendSize();
+    }
 }

--- a/Block/Turnstile.php
+++ b/Block/Turnstile.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace PixelOpen\CloudflareTurnstile\Block;
 
 use PixelOpen\CloudflareTurnstile\Helper\Config;
+use PixelOpen\CloudflareTurnstile\Model\Config\Source\RenderingMode;
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 use Magento\Framework\Filter\FilterManager;
@@ -135,5 +136,35 @@ class Turnstile extends Template
     public function getSizeFromConfig(): string
     {
         return $this->getSize() ?: $this->config->getFrontendSize();
+    }
+
+    /**
+     * Retrieve configured rendering mode
+     *
+     * @return string
+     */
+    public function getRenderingMode(): string
+    {
+        return $this->config->getFrontendRenderingMode();
+    }
+
+    /**
+     * Use Knockout rendering (Luma/Blank themes)
+     *
+     * @return bool
+     */
+    public function isKnockoutRendering(): bool
+    {
+        return $this->getRenderingMode() === RenderingMode::MODE_KNOCKOUT;
+    }
+
+    /**
+     * Use Hyvä/Alpine fallback rendering
+     *
+     * @return bool
+     */
+    public function isFallbackRendering(): bool
+    {
+        return $this->getRenderingMode() === RenderingMode::MODE_FALLBACK;
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 100.4.0
+
+- Added storefront setting to choose the widget rendering mode (Knockout vs Hyvä/Alpine fallback)
+- Ensured only one renderer executes at a time to prevent Cloudflare "sitekey object" errors
+- Added dedicated fallback container class (`cf-turnstile-manual`) so Turnstile auto-render does not attach to Hyvä widgets
+- Improved frontend/admin CSS and JS to respect the selected rendering mode
+
 ## 100.3.0
 
 - Allow adding a captcha to the native newsletter subscription block ([2](https://github.com/Pixel-Open/magento-cloudflare-turnstile/issues/2))

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -12,6 +12,7 @@ namespace PixelOpen\CloudflareTurnstile\Helper;
 
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Store\Model\ScopeInterface;
+use PixelOpen\CloudflareTurnstile\Model\Config\Source\RenderingMode;
 
 class Config extends AbstractHelper
 {
@@ -22,6 +23,7 @@ class Config extends AbstractHelper
     public const TURNSTILE_CONFIG_PATH_FRONTEND_THEME = 'pixel_open_cloudflare_turnstile/frontend/theme';
     public const TURNSTILE_CONFIG_PATH_FRONTEND_SIZE = 'pixel_open_cloudflare_turnstile/frontend/size';
     public const TURNSTILE_CONFIG_PATH_FRONTEND_FORMS = 'pixel_open_cloudflare_turnstile/frontend/forms';
+    public const TURNSTILE_CONFIG_PATH_FRONTEND_RENDERING_MODE = 'pixel_open_cloudflare_turnstile/frontend/rendering_mode';
 
     public const TURNSTILE_CONFIG_PATH_ADMINHTML_ENABLED = 'pixel_open_cloudflare_turnstile/adminhtml/enabled';
     public const TURNSTILE_CONFIG_PATH_ADMINHTML_THEME = 'pixel_open_cloudflare_turnstile/adminhtml/theme';
@@ -117,6 +119,21 @@ class Config extends AbstractHelper
             self::TURNSTILE_CONFIG_PATH_FRONTEND_SIZE,
             ScopeInterface::SCOPE_STORE
         );
+    }
+
+    /**
+     * Retrieve frontend rendering mode
+     *
+     * @return string
+     */
+    public function getFrontendRenderingMode(): string
+    {
+        $mode = $this->scopeConfig->getValue(
+            self::TURNSTILE_CONFIG_PATH_FRONTEND_RENDERING_MODE,
+            ScopeInterface::SCOPE_STORE
+        );
+
+        return $mode ?: RenderingMode::MODE_KNOCKOUT;
     }
 
     /**

--- a/Model/Config/Source/RenderingMode.php
+++ b/Model/Config/Source/RenderingMode.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright (C) 2023 Pixel Développement
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PixelOpen\CloudflareTurnstile\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+class RenderingMode implements OptionSourceInterface
+{
+    public const MODE_KNOCKOUT = 'knockout';
+
+    public const MODE_FALLBACK = 'fallback';
+
+    /**
+     * Retrieve option array
+     *
+     * @return array
+     */
+    public function toOptionArray(): array
+    {
+        return [
+            [
+                'value' => self::MODE_KNOCKOUT,
+                'label' => __('Knockout (Luma/Blank themes)'),
+            ],
+            [
+                'value' => self::MODE_FALLBACK,
+                'label' => __('Hyvä / Alpine fallback'),
+            ],
+        ];
+    }
+}
+

--- a/Model/ConfigProvider/Frontend.php
+++ b/Model/ConfigProvider/Frontend.php
@@ -35,9 +35,10 @@ class Frontend implements ConfigProviderInterface
             'config' => [
                 'enabled' => $this->config->isEnabledOnFront(),
                 'sitekey' => $this->config->getSiteKey(),
-                'theme'   => $this->config->getFrontendTheme(),
-                'size'    => $this->config->getFrontendSize(),
-                'forms'   => $this->config->getFrontendForms(),
+                'theme'          => $this->config->getFrontendTheme(),
+                'size'           => $this->config->getFrontendSize(),
+                'forms'          => $this->config->getFrontendForms(),
+                'renderingMode'  => $this->config->getFrontendRenderingMode(),
             ]
         ];
     }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 ## Installation
 
 ```
-composer require pixelopen/magento-cloudflare-turnstile
+composer require shinesoftware/magento-cloudflare-turnstile
 ```
 
 ## Configuration

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "pixelopen/magento-cloudflare-turnstile",
+  "name": "shinesoftware/magento-cloudflare-turnstile",
   "description": "Protect your store from spam messages and spam user accounts with Cloudflare Turnstile",
   "require": {
     "php": "^8",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "magento/framework": "*"
   },
   "type": "magento2-module",
-  "version": "100.3.0",
+  "version": "100.4.0",
   "autoload": {
     "files": [
       "registration.php"

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "magento/framework": "*"
   },
   "type": "magento2-module",
-  "version": "100.4.0",
+  "version": "100.3.1",
   "autoload": {
     "files": [
       "registration.php"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "shinesoftware/magento-cloudflare-turnstile",
+  "name": "pixelopen/cloudflare-turnstile-bundle",
   "description": "Protect your store from spam messages and spam user accounts with Cloudflare Turnstile",
   "require": {
     "php": "^8",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "pixelopen/cloudflare-turnstile-bundle",
+  "name": "pixelopen/magento-cloudflare-turnstile",
   "description": "Protect your store from spam messages and spam user accounts with Cloudflare Turnstile",
   "require": {
     "php": "^8",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -30,6 +30,14 @@
                     <label>Enabled</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="rendering_mode" translate="label comment" type="select" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Rendering mode</label>
+                    <source_model>PixelOpen\CloudflareTurnstile\Model\Config\Source\RenderingMode</source_model>
+                    <comment><![CDATA[Select how the widget is rendered. Use <strong>Knockout</strong> for Luma/Blank based themes, or the <strong>Hyvä / Alpine fallback</strong> when Knockout is not available.]]></comment>
+                    <depends>
+                        <field id="enabled">1</field>
+                    </depends>
+                </field>
                 <field id="theme" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Theme</label>
                     <source_model>PixelOpen\CloudflareTurnstile\Model\Config\Source\Theme</source_model>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -14,6 +14,7 @@
                 <enabled>0</enabled>
                 <theme>light</theme>
                 <size>normal</size>
+                <rendering_mode>knockout</rendering_mode>
             </frontend>
             <adminhtml>
                 <enabled>0</enabled>

--- a/view/adminhtml/web/css/turnstile.css
+++ b/view/adminhtml/web/css/turnstile.css
@@ -5,4 +5,9 @@
 .cloudflare-turnstile {
     font-weight: bold;
     color: #c00;
+    margin-top: 1rem;
+}
+
+.cloudflare-turnstile .cf-turnstile {
+    margin-top: 0;
 }

--- a/view/adminhtml/web/css/turnstile.css
+++ b/view/adminhtml/web/css/turnstile.css
@@ -8,11 +8,11 @@
     margin-top: 1rem;
 }
 
-.cloudflare-turnstile .cf-turnstile,
-.cloudflare-turnstile .cf-turnstile-manual {
+.cf-turnstile-manual {
     margin-top: 0;
+    min-height: 65px;
 }
 
-.cf-turnstile-manual {
-    min-height: 65px;
+.cloudflare-turnstile .cf-turnstile {
+    margin-top: 0;
 }

--- a/view/adminhtml/web/css/turnstile.css
+++ b/view/adminhtml/web/css/turnstile.css
@@ -8,6 +8,11 @@
     margin-top: 1rem;
 }
 
-.cloudflare-turnstile .cf-turnstile {
+.cloudflare-turnstile .cf-turnstile,
+.cloudflare-turnstile .cf-turnstile-manual {
     margin-top: 0;
+}
+
+.cf-turnstile-manual {
+    min-height: 65px;
 }

--- a/view/base/templates/turnstile.phtml
+++ b/view/base/templates/turnstile.phtml
@@ -17,6 +17,9 @@ $isFormEnabled = $block->isFormEnabled();
 $theme = $block->getThemeFromConfig();
 $size = $block->getSizeFromConfig();
 $elementId = $block->getId();
+$renderingMode = $block->getRenderingMode();
+$isKnockout = $block->isKnockoutRendering();
+$isFallback = $block->isFallbackRendering();
 
 // Early return if not enabled
 if (!$isEnabled || !$isFormEnabled || !$sitekey) {
@@ -29,27 +32,37 @@ if (!$isEnabled || !$isFormEnabled || !$sitekey) {
      data-sitekey="<?= $escaper->escapeHtmlAttr($sitekey) ?>"
      data-theme="<?= $escaper->escapeHtmlAttr($theme) ?>"
      data-size="<?= $escaper->escapeHtmlAttr($size) ?>"
-     data-bind="scope:'cloudflare-turnstile-<?= $escaper->escapeHtmlAttr($elementId) ?>'">
-    <!-- ko template: getTemplate() --><!-- /ko -->
-    <!-- Fallback container for themes without Knockout.js (e.g., Hyvä Theme) -->
-    <div id="cf-turnstile-fallback-<?= $escaper->escapeHtmlAttr($elementId) ?>" class="cf-turnstile" style="display: none;"></div>
+     data-render-mode="<?= $escaper->escapeHtmlAttr($renderingMode) ?>"
+     <?php if ($isKnockout): ?>
+     data-bind="scope:'cloudflare-turnstile-<?= $escaper->escapeHtmlAttr($elementId) ?>'"
+     <?php endif; ?>
+>
+    <?php if ($isKnockout): ?>
+        <!-- ko template: getTemplate() --><!-- /ko -->
+    <?php endif; ?>
+    <?php if ($isFallback): ?>
+        <!-- Fallback container for themes without Knockout.js (e.g., Hyvä Theme) -->
+        <div id="cf-turnstile-fallback-<?= $escaper->escapeHtmlAttr($elementId) ?>" class="cf-turnstile-manual" style="display: none;"></div>
+    <?php endif; ?>
 </div>
 
-<script type="text/x-magento-init">
-{
-    "#<?= $escaper->escapeJs($elementId) ?>": {
-        "Magento_Ui/js/core/app": {
-            "components": {
-                "cloudflare-turnstile-<?= $escaper->escapeJs($elementId) ?>": {
-                    "component": "PixelOpen_CloudflareTurnstile/js/view/turnstile",
-                    "action": "<?= $escaper->escapeJs($action) ?>",
-                    "size": "<?= $escaper->escapeJs($size) ?>",
-                    "theme": "<?= $escaper->escapeJs($theme) ?>",
-                    "configSource": "turnstileConfig"
+<?php if ($isKnockout): ?>
+    <script type="text/x-magento-init">
+    {
+        "#<?= $escaper->escapeJs($elementId) ?>": {
+            "Magento_Ui/js/core/app": {
+                "components": {
+                    "cloudflare-turnstile-<?= $escaper->escapeJs($elementId) ?>": {
+                        "component": "PixelOpen_CloudflareTurnstile/js/view/turnstile",
+                        "action": "<?= $escaper->escapeJs($action) ?>",
+                        "size": "<?= $escaper->escapeJs($size) ?>",
+                        "theme": "<?= $escaper->escapeJs($theme) ?>",
+                        "configSource": "turnstileConfig"
+                    }
                 }
             }
         }
     }
-}
-</script>
+    </script>
+<?php endif; ?>
 

--- a/view/base/templates/turnstile.phtml
+++ b/view/base/templates/turnstile.phtml
@@ -1,18 +1,50 @@
-<?php /** @var \PixelOpen\CloudflareTurnstile\Block\Turnstile $block */ ?>
-<?php /** @var \Magento\Framework\Escaper $escaper */ ?>
-<div id="<?= $escaper->escapeHtmlAttr($block->getId()) ?>" class="cloudflare-turnstile" data-bind="scope:'cloudflare-turnstile-<?= $escaper->escapeHtmlAttr($block->getId()) ?>'">
+<?php
+/**
+ * Copyright (C) 2023 Pixel Développement
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/** @var \PixelOpen\CloudflareTurnstile\Block\Turnstile $block */
+/** @var \Magento\Framework\Escaper $escaper */
+
+// Get configuration values from block
+$isEnabled = $block->isEnabled();
+$sitekey = $block->getSiteKey();
+$action = $block->getAction();
+$isFormEnabled = $block->isFormEnabled();
+$theme = $block->getThemeFromConfig();
+$size = $block->getSizeFromConfig();
+$elementId = $block->getId();
+
+// Early return if not enabled
+if (!$isEnabled || !$isFormEnabled || !$sitekey) {
+    return;
+}
+?>
+
+<div id="<?= $escaper->escapeHtmlAttr($elementId) ?>" class="cloudflare-turnstile" 
+     data-action="<?= $escaper->escapeHtmlAttr($action) ?>"
+     data-sitekey="<?= $escaper->escapeHtmlAttr($sitekey) ?>"
+     data-theme="<?= $escaper->escapeHtmlAttr($theme) ?>"
+     data-size="<?= $escaper->escapeHtmlAttr($size) ?>"
+     data-bind="scope:'cloudflare-turnstile-<?= $escaper->escapeHtmlAttr($elementId) ?>'">
     <!-- ko template: getTemplate() --><!-- /ko -->
+    <!-- Fallback container for themes without Knockout.js (e.g., Hyvä Theme) -->
+    <div id="cf-turnstile-fallback-<?= $escaper->escapeHtmlAttr($elementId) ?>" class="cf-turnstile" style="display: none;"></div>
 </div>
+
 <script type="text/x-magento-init">
 {
-    "#<?= $escaper->escapeJs($block->getId()) ?>": {
+    "#<?= $escaper->escapeJs($elementId) ?>": {
         "Magento_Ui/js/core/app": {
             "components": {
-                "cloudflare-turnstile-<?= $escaper->escapeJs($block->getId()) ?>": {
+                "cloudflare-turnstile-<?= $escaper->escapeJs($elementId) ?>": {
                     "component": "PixelOpen_CloudflareTurnstile/js/view/turnstile",
-                    "action": "<?= $escaper->escapeJs($block->getAction()) ?>",
-                    "size": "<?= $escaper->escapeJs($block->getSize()) ?>",
-                    "theme": "<?= $escaper->escapeJs($block->getTheme()) ?>",
+                    "action": "<?= $escaper->escapeJs($action) ?>",
+                    "size": "<?= $escaper->escapeJs($size) ?>",
+                    "theme": "<?= $escaper->escapeJs($theme) ?>",
                     "configSource": "turnstileConfig"
                 }
             }
@@ -20,3 +52,4 @@
     }
 }
 </script>
+

--- a/view/base/templates/turnstile.phtml
+++ b/view/base/templates/turnstile.phtml
@@ -27,7 +27,7 @@ if (!$isEnabled || !$isFormEnabled || !$sitekey) {
 }
 ?>
 
-<div id="<?= $escaper->escapeHtmlAttr($elementId) ?>" class="cloudflare-turnstile" 
+<div id="<?= $escaper->escapeHtmlAttr($elementId) ?>" class="cloudflare-turnstile"
      data-action="<?= $escaper->escapeHtmlAttr($action) ?>"
      data-sitekey="<?= $escaper->escapeHtmlAttr($sitekey) ?>"
      data-theme="<?= $escaper->escapeHtmlAttr($theme) ?>"

--- a/view/base/web/js/fallback.js
+++ b/view/base/web/js/fallback.js
@@ -1,0 +1,197 @@
+/**
+ * Copyright (C) 2023 Pixel Développement
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Fallback for themes without Knockout.js (e.g., Hyvä Theme)
+ * This script only activates if Knockout.js is not available or fails to render
+ */
+(function() {
+    'use strict';
+    
+    /**
+     * Initialize fallback for a specific container
+     * 
+     * @param {string} elementId - The ID of the container element
+     */
+    function initFallback(elementId) {
+        const container = document.getElementById(elementId);
+        const fallbackContainer = document.getElementById('cf-turnstile-fallback-' + elementId);
+        
+        if (!container || !fallbackContainer) {
+            return;
+        }
+        
+        // Check if Knockout.js is available
+        function isKnockoutAvailable() {
+            // Check if ko is defined globally or if Magento UI components are available
+            return typeof window.ko !== 'undefined' || 
+                   (typeof window.require !== 'undefined' && window.require.specified && window.require.specified('ko'));
+        }
+        
+        // Check if Knockout has rendered the widget
+        function hasKnockoutRendered() {
+            // Look for the widget rendered by Knockout (it should have a cf-turnstile class but not our fallback ID)
+            const koWidget = container.querySelector('.cf-turnstile:not([id*="cf-turnstile-fallback-"])');
+            // Also check if there's a cf-turnstile-response input (which means the widget was rendered)
+            const form = container.closest('form');
+            const hasResponseInput = form && form.querySelector('input[name="cf-turnstile-response"]');
+            return koWidget !== null || hasResponseInput !== null;
+        }
+        
+        // Initialize fallback after checking if Knockout is working
+        function init() {
+            // Only use fallback if Knockout is not available or didn't render
+            if (isKnockoutAvailable()) {
+                // Knockout is available, wait a bit to see if it renders
+                setTimeout(function() {
+                    if (!hasKnockoutRendered()) {
+                        // Knockout is available but didn't render, use fallback
+                        activateFallback();
+                    }
+                }, 1000); // Wait 1 second for Knockout to initialize and render
+            } else {
+                // Knockout is not available, use fallback immediately
+                activateFallback();
+            }
+        }
+        
+        // Activate the fallback widget
+        function activateFallback() {
+            // Make sure we don't activate if Knockout already rendered
+            if (hasKnockoutRendered()) {
+                return;
+            }
+            
+            fallbackContainer.style.display = 'block';
+            
+            // Configuration from data attributes
+            const config = {
+                sitekey: container.getAttribute('data-sitekey'),
+                theme: container.getAttribute('data-theme') || 'auto',
+                size: container.getAttribute('data-size') || 'normal',
+                action: container.getAttribute('data-action')
+            };
+            
+            // Load Cloudflare Turnstile script if not already loaded
+            function loadTurnstileScript() {
+                if (window.turnstile) {
+                    renderWidget();
+                    return;
+                }
+                
+                // Check if script is already being loaded
+                if (document.querySelector('script[src*="challenges.cloudflare.com/turnstile"]')) {
+                    // Wait for script to load
+                    const checkInterval = setInterval(function() {
+                        if (window.turnstile) {
+                            clearInterval(checkInterval);
+                            renderWidget();
+                        }
+                    }, 100);
+                    
+                    // Timeout after 10 seconds
+                    setTimeout(function() {
+                        clearInterval(checkInterval);
+                        if (!window.turnstile) {
+                            console.error('Cloudflare Turnstile: Script failed to load');
+                            fallbackContainer.innerText = 'Unable to load security verification. Please refresh the page.';
+                        }
+                    }, 10000);
+                    
+                    return;
+                }
+                
+                // Load the script
+                const script = document.createElement('script');
+                script.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js';
+                script.async = true;
+                script.defer = true;
+                script.onload = function() {
+                    renderWidget();
+                };
+                script.onerror = function() {
+                    console.error('Cloudflare Turnstile: Failed to load script');
+                    fallbackContainer.innerText = 'Unable to load security verification. Please refresh the page.';
+                };
+                document.head.appendChild(script);
+            }
+            
+            // Render the widget
+            function renderWidget() {
+                if (!window.turnstile || !window.turnstile.render) {
+                    console.error('Cloudflare Turnstile: turnstile object not available');
+                    fallbackContainer.innerText = 'Unable to initialize security verification.';
+                    return;
+                }
+                
+                // Double check that Knockout didn't render in the meantime
+                if (hasKnockoutRendered()) {
+                    fallbackContainer.style.display = 'none';
+                    return;
+                }
+                
+                try {
+                    const widgetId = window.turnstile.render(fallbackContainer, {
+                        sitekey: config.sitekey,
+                        theme: config.theme,
+                        size: config.size,
+                        action: config.action
+                    });
+                    
+                    if (typeof widgetId === 'undefined') {
+                        console.error('Cloudflare Turnstile: Failed to render widget');
+                        fallbackContainer.innerText = 'Unable to secure the form.';
+                    } else {
+                        // Store widget ID for potential reset
+                        fallbackContainer.setAttribute('data-widget-id', widgetId);
+                    }
+                } catch (error) {
+                    console.error('Cloudflare Turnstile: Error rendering widget', error);
+                    fallbackContainer.innerText = 'Unable to secure the form.';
+                }
+            }
+            
+            // Initialize when DOM is ready
+            if (document.readyState === 'loading') {
+                document.addEventListener('DOMContentLoaded', loadTurnstileScript);
+            } else {
+                // DOM is already ready
+                loadTurnstileScript();
+            }
+        }
+        
+        // Start checking after DOM is ready
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', init);
+        } else {
+            init();
+        }
+    }
+    
+    // Auto-initialize all containers with class 'cloudflare-turnstile' that have data attributes
+    function autoInit() {
+        const containers = document.querySelectorAll('.cloudflare-turnstile[data-sitekey]');
+        containers.forEach(function(container) {
+            if (container.id) {
+                initFallback(container.id);
+            }
+        });
+    }
+    
+    // Initialize when DOM is ready
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', autoInit);
+    } else {
+        autoInit();
+    }
+    
+    // Export function for manual initialization if needed
+    window.CloudflareTurnstileFallback = {
+        init: initFallback
+    };
+})();
+

--- a/view/base/web/js/view/component.js
+++ b/view/base/web/js/view/component.js
@@ -75,14 +75,15 @@ define(
                 // Extract sitekey value from observable if needed
                 const sitekey = this.getValue(this.config.sitekey);
                 
-                if (!sitekey) {
-                    this.element.innerText = $.mage.__('Unable to secure the form. The site key is missing.');
-                } else {
+                if (sitekey) {
                     this.beforeRender();
                     if (this.autoRendering) {
                         this.render();
                     }
+                    return;
                 }
+
+                this.element.innerText = $.mage.__('Unable to secure the form. The site key is missing.');
             },
 
             /**
@@ -92,7 +93,7 @@ define(
              * @returns {*}
              */
             getValue: function (value) {
-                if (typeof ko !== 'undefined' && ko.isObservable(value)) {
+                if (ko && ko.isObservable(value)) {
                     return ko.unwrap(value);
                 }
                 return value;

--- a/view/base/web/js/view/component.js
+++ b/view/base/web/js/view/component.js
@@ -93,7 +93,7 @@ define(
              * @returns {*}
              */
             getValue: function (value) {
-                if (ko && ko.isObservable(value)) {
+                if (ko?.isObservable(value)) {
                     return ko.unwrap(value);
                 }
                 return value;

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -10,6 +10,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
         <css src="PixelOpen_CloudflareTurnstile::css/turnstile.css"/>
+        <script src="PixelOpen_CloudflareTurnstile::js/fallback.js"/>
     </head>
     <body>
         <referenceContainer name="before.body.end">

--- a/view/frontend/web/css/turnstile.css
+++ b/view/frontend/web/css/turnstile.css
@@ -4,11 +4,11 @@
     margin-top: 1rem;
 }
 
-.cloudflare-turnstile .cf-turnstile,
-.cloudflare-turnstile .cf-turnstile-manual {
+.cf-turnstile-manual {
     margin-top: 0;
+    min-height: 65px;
 }
 
-.cf-turnstile-manual {
-    min-height: 65px;
+.cloudflare-turnstile .cf-turnstile {
+    margin-top: 0;
 }

--- a/view/frontend/web/css/turnstile.css
+++ b/view/frontend/web/css/turnstile.css
@@ -4,6 +4,11 @@
     margin-top: 1rem;
 }
 
-.cloudflare-turnstile .cf-turnstile {
+.cloudflare-turnstile .cf-turnstile,
+.cloudflare-turnstile .cf-turnstile-manual {
     margin-top: 0;
+}
+
+.cf-turnstile-manual {
+    min-height: 65px;
 }

--- a/view/frontend/web/css/turnstile.css
+++ b/view/frontend/web/css/turnstile.css
@@ -1,4 +1,9 @@
 .cloudflare-turnstile {
     font-weight: bold;
     color: #c00;
+    margin-top: 1rem;
+}
+
+.cloudflare-turnstile .cf-turnstile {
+    margin-top: 0;
 }


### PR DESCRIPTION
- Implemented methods in Turnstile block to check if Turnstile is enabled, retrieve site key, and manage form settings.
- Enhanced turnstile.phtml to utilize new block methods for configuration and added fallback for themes without Knockout.js.
- Introduced fallback.js to handle rendering when Knockout.js is unavailable.
- Updated CSS for improved styling of Turnstile elements.
- Included fallback.js in the layout for frontend integration.