### PR TITLE
turnstile message manager mesages from ajax form submits not being refreshed on page.

### DIFF
--- a/Observer/Validate.php
+++ b/Observer/Validate.php
@@ -48,7 +48,6 @@ abstract class Validate implements ObserverInterface
 
     /**
      * @param ManagerInterface $messageManager
-     * @param Response $response
      * @param Validator $validator
      * @param Json $json
      * @param Config $config
@@ -57,7 +56,6 @@ abstract class Validate implements ObserverInterface
      */
     public function __construct(
         ManagerInterface $messageManager,
-        Response $response,
         RedirectInterface $redirect,
         Validator $validator,
         Json $json,
@@ -66,7 +64,6 @@ abstract class Validate implements ObserverInterface
         array $data = []
     ) {
         $this->messageManager = $messageManager;
-        $this->response       = $response;
         $this->redirect       = $redirect;
         $this->validator      = $validator;
         $this->json           = $json;
@@ -83,8 +80,9 @@ abstract class Validate implements ObserverInterface
      */
     public function execute(Observer $observer): void
     {
-        $this->action = $observer->getEvent()->getData('controller_action');
-        $this->request = $observer->getEvent()->getData('request');
+        $this->action   = $observer->getEvent()->getData('controller_action');
+        $this->request  = $observer->getEvent()->getData('request');
+        $this->response = $this->action->getResponse();
 
         if ($this->canValidate()) {
             try {
@@ -119,7 +117,8 @@ abstract class Validate implements ObserverInterface
     protected function error(Phrase $message): void
     {
         $this->messageManager->addErrorMessage($message);
-        $this->redirect->redirect($this->action->getResponse(), $this->redirect->getRefererUrl());
+        $this->redirect->redirect($this->response, $this->redirect->getRefererUrl());
+
         exit();
     }
 

--- a/Observer/Validate.php
+++ b/Observer/Validate.php
@@ -14,6 +14,7 @@ use Exception;
 use Magento\Framework\App\ActionInterface;
 use Magento\Framework\App\Request\Http as Request;
 use Magento\Framework\App\Response\Http as Response;
+use Magento\Framework\App\Response\RedirectInterface;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Message\ManagerInterface;
@@ -28,6 +29,8 @@ abstract class Validate implements ObserverInterface
     protected ManagerInterface $messageManager;
 
     protected Response $response;
+
+    protected RedirectInterface $redirect;
 
     protected Validator $validator;
 
@@ -55,6 +58,7 @@ abstract class Validate implements ObserverInterface
     public function __construct(
         ManagerInterface $messageManager,
         Response $response,
+        RedirectInterface $redirect,
         Validator $validator,
         Json $json,
         Config $config,
@@ -63,6 +67,7 @@ abstract class Validate implements ObserverInterface
     ) {
         $this->messageManager = $messageManager;
         $this->response       = $response;
+        $this->redirect       = $redirect;
         $this->validator      = $validator;
         $this->json           = $json;
         $this->config         = $config;
@@ -114,9 +119,7 @@ abstract class Validate implements ObserverInterface
     protected function error(Phrase $message): void
     {
         $this->messageManager->addErrorMessage($message);
-        $this->response->setRedirect($this->request?->getServer('HTTP_REFERER', '/') ?? '/');
-
-        $this->response->sendResponse();
+        $this->redirect->redirect($this->action->getResponse(), $this->redirect->getRefererUrl());
         exit();
     }
 

--- a/Observer/Validate/Frontend.php
+++ b/Observer/Validate/Frontend.php
@@ -13,6 +13,7 @@ namespace PixelOpen\CloudflareTurnstile\Observer\Validate;
 use Magento\Customer\Controller\Ajax\Login as AjaxLoginPost;
 use Magento\Customer\Model\Session as CustomerSession;
 use Magento\Framework\App\Response\Http as Response;
+use Magento\Framework\App\Response\RedirectInterface;
 use Magento\Framework\Message\ManagerInterface;
 use Magento\Framework\Phrase;
 use Magento\Framework\Serialize\Serializer\Json;
@@ -38,6 +39,7 @@ class Frontend extends Validate
     public function __construct(
         ManagerInterface $messageManager,
         Response $response,
+        RedirectInterface $redirect,
         Validator $validator,
         Json $json,
         Config $config,
@@ -47,7 +49,7 @@ class Frontend extends Validate
     ) {
         $this->customerSession = $customerSession;
 
-        parent::__construct($messageManager, $response, $validator, $json, $config, $persistor, $data);
+        parent::__construct($messageManager, $response, $redirect, $validator, $json, $config, $persistor, $data);
     }
 
 

--- a/Observer/Validate/Frontend.php
+++ b/Observer/Validate/Frontend.php
@@ -12,7 +12,6 @@ namespace PixelOpen\CloudflareTurnstile\Observer\Validate;
 
 use Magento\Customer\Controller\Ajax\Login as AjaxLoginPost;
 use Magento\Customer\Model\Session as CustomerSession;
-use Magento\Framework\App\Response\Http as Response;
 use Magento\Framework\App\Response\RedirectInterface;
 use Magento\Framework\Message\ManagerInterface;
 use Magento\Framework\Phrase;
@@ -28,7 +27,6 @@ class Frontend extends Validate
 
     /**
      * @param ManagerInterface $messageManager
-     * @param Response $response
      * @param Validator $validator
      * @param Json $json
      * @param Config $config
@@ -38,9 +36,8 @@ class Frontend extends Validate
      */
     public function __construct(
         ManagerInterface $messageManager,
-        Response $response,
-        RedirectInterface $redirect,
         Validator $validator,
+        RedirectInterface $redirect,
         Json $json,
         Config $config,
         CustomerSession $customerSession,
@@ -49,7 +46,7 @@ class Frontend extends Validate
     ) {
         $this->customerSession = $customerSession;
 
-        parent::__construct($messageManager, $response, $redirect, $validator, $json, $config, $persistor, $data);
+        parent::__construct($messageManager, $redirect, $validator, $json, $config, $persistor, $data);
     }
 
 


### PR DESCRIPTION
If submitting a form ajax style from a web page(not a AjaxLoginPost) , the original redirect would be eaten and any messages to the messageManager from turnstile event observer would not show up until manually reloading page. Using Magento RedirectInterface to do the redirect will then show the MessageManager messages on the page without a forced page reload.